### PR TITLE
Add support for EasyNews++

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Expose the port the app will run on
-EXPOSE 5000
+EXPOSE 5001
 
 # Define environment variable (optional)
 ENV FLASK_APP=fakearr.py

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Grab a [7-day trial for $1](https://store.elfhosted.com/product/hobbit-plex-easy
 ## Features
 
 - Acts as a NewzNab indexer for seamless integration.
-- Compatible with DebriDav and EasyNews.
+- Compatible with DebriDav, Radarr, Sonarr, and Prowlarr.
+- Supports both [EasyNews+](https://github.com/Sleeyax/stremio-easynews-addon) and [EasyNews++](https://github.com/panteLx/easynews-plus-plus).
 - Provides fake NZB files for testing and development purposes.
 
 ## Screenshots
 
-Here's what Fakearr can enable in Radarr/Sonarr:
+Here's what FakeArr can enable in Radarr/Sonarr:
 
 ![](screenshots/fakearr-radarr-search.png)
 
@@ -24,17 +25,40 @@ And here's how to enable it in Prowlarr:
 
 ![](screenshots/fakearr-prowlarr.png)
 
-
 ## Environment Variables
 
 To configure FakeArr, set the following environment variables:
 
 | Variable            | Default Value                                   | Description                                   |
 |---------------------|-------------------------------------------------|-----------------------------------------------|
-| `EASYNEWSPLUS_URL`  | `http://elfhosted-internal.easynewsplus`        | Base URL for the Stremio addon.              |
-| `EASYNEWS_USERNAME` | `default_user`                                  | Username for EasyNews authentication.        |
-| `EASYNEWS_PASSWORD` | `default_pass`                                  | Password for EasyNews authentication.        |
-| `FAKEARR_BASE_URL`  | `http://debridav:5001`                          | Base URL for FakeArr. Needs to be reachable from Aars                        |
+| `EASYNEWS_VERSION`  | `plus`                                          | Choose between `plus` (Sleeyax) or `plusplus` (panteLx).                     |
+| `EASYNEWS_ADDON_URL`| `http://elfhosted-internal.easynewsplus`        | Base URL of the Stremio EasyNews addon.       |
+| `EASYNEWS_USERNAME` | `default_user`                                  | Username for EasyNews authentication.         |
+| `EASYNEWS_PASSWORD` | `default_pass`                                  | Password for EasyNews authentication.         |
+| `FAKEARR_BASE_URL`  | `http://debridav:5001`                          | Base URL for FakeArr. Needs to be reachable from Aars.                       |
+
+### Optional: EasyNews+ (Sleeyax) specific
+
+| Variable               | Default       | Description             |
+|------------------------|---------------|-------------------------|
+| `EASYNEWS_SORT1`       | `Size`        | Primary sort field      |
+| `EASYNEWS_SORT1_DIR`   | `Descending`  | Sort direction          |
+| `EASYNEWS_SORT2`       | `Relevance`   | Secondary sort field    |
+| `EASYNEWS_SORT2_DIR`   | `Descending`  | Sort direction          |
+| `EASYNEWS_SORT3`       | `Date & Time` | Tertiary sort field     |
+| `EASYNEWS_SORT3_DIR`   | `Descending`  | Sort direction          |
+
+### Optional: EasyNews++ (panteLx) specific
+
+| Variable                             | Default                      | Description                                           |
+|--------------------------------------|------------------------------|-------------------------------------------------------|
+| `EASYNEWS_UI_LANGUAGE`               | `eng`                        | Interface language                                    |
+| `EASYNEWS_STRICT_TITLE_MATCHING`     | `on`                         | Whether strict title matching is enabled              |
+| `EASYNEWS_PREFERRED_LANGUAGE`        | ``                           | Preferred audio language                              |
+| `EASYNEWS_SORTING_PREFERENCE`        | `quality_first`              | Sorting method (quality, language, size or date)      |
+| `EASYNEWS_SHOW_QUALITIES`            | `4k,1080p,720p,480p`         | Qualities to include                                  |
+| `EASYNEWS_MAX_RESULTS_PER_QUALITY`   | ``                           | Max results per quality                               |
+| `EASYNEWS_MAX_FILE_SIZE`             | ``                           | Max file size in GB                                   |
 
 ## Getting Started
 
@@ -57,12 +81,16 @@ To configure FakeArr, set the following environment variables:
 
 ```
 docker run -d -p 5001:5001 \
-  -e EASYNEWSPLUS_URL=https://easynewsplus.elfhosted.com \
+  -e EASYNEWS_VERSION=plus \
+  -e EASYNEWS_ADDON_URL=https://easynewsplus.elfhosted.com \
   -e EASYNEWS_USERNAME=my_user \
   -e EASYNEWS_PASSWORD=my_pass \
   -e FAKEARR_BASE_URL=http://fakearr:5001 \
   --name fakearr ghcr.io/elfhosted/fakearr:rolling
   ```
+You can also add additional parameters for EasyNews+ (e.g. `EASYNEWS_SORT1`, `EASYNEWS_SORT2`, etc.) and EasyNews++ (e.g. `EASYNEWS_STRICT_TITLE_MATCHING`, `EASYNEWS_SORTING_PREFERENCE`, etc.) depending on the EasyNews addon you are using.
+
+Refer to `sample.env` for a complete list of supported environment variables.
 
 ## License
 
@@ -81,4 +109,5 @@ For more details, see the full license text at [https://creativecommons.org/lice
 # Acknowledgments
 
 * Inspired by Puks The Pirate's original fake-torrent-server. See Puk's work at https://savvyguides.wiki/
-* EasyNews search is made possible by https://github.com/sleeyax/stremio-easynews-addon
+* EasyNews+ is made possible by [Sleeyax](https://github.com/sleeyax/stremio-easynews-addon)
+* EasyNews++ is made possible by [panteLx](https://github.com/panteLx/easynews-plus-plus)

--- a/fakearr.py
+++ b/fakearr.py
@@ -150,8 +150,18 @@ def newznab_api():
         ET.SubElement(channel, "language").text = "en-us"
 
         for result in results:
-            title = result.get("behaviorHints", {}).get("fileName") or result.get("name", "Unknown Title")
-            size = str(result.get("behaviorHints", {}).get("videoSize", 104857600))
+            behavior = result.get("behaviorHints", {})
+
+            if EASYNEWS_VERSION == "plus":
+                title = behavior.get("fileName") or result.get("name", "Unknown Title")
+                size = str(behavior.get("videoSize", 104857600))
+            elif EASYNEWS_VERSION == "plusplus":
+                title = behavior.get("filename") or result.get("name", "Unknown Title")
+                size = str(behavior.get("rawSize", 104857600))
+            else:
+                title = result.get("name", "Unknown Title")
+                size = str(104857600)
+
             quality = result.get("name", "Unknown Quality")
             nzb_url = f"{FAKEARR_BASE_URL}/fake_nzb/{title}.nzb"
 

--- a/fakearr.py
+++ b/fakearr.py
@@ -153,7 +153,7 @@ def newznab_api():
                 group = "alt.binaries.example"
 
             elif EASYNEWS_VERSION == "plusplus":
-                title = result.get("behaviorHints", {}).get("filename") or result.get("name", "Unknown Title")
+                title = result.get("_temp", {}).get("file", {}).get("10") or result.get("name", "Unknown Title")
                 size = str(result.get("_temp", {}).get("file", {}).get("rawSize", 104857600))
                 quality = result.get("name", "Unknown Quality")
                 raw_date = result.get("_temp", {}).get("file", {}).get("5", "")

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,78 @@
+# ===================================================
+# General configuration
+# ===================================================
+
+# Choose addon type: 'plus' (EasyNews+ by Sleeyax) or 'plusplus' (EasyNews++ by panteLx)
+EASYNEWS_VERSION=plusplus
+
+# Base URL of the EasyNews addon
+EASYNEWS_ADDON_URL=https://en.pantelx.com/
+
+# Your EasyNews account credentials
+EASYNEWS_USERNAME=default_user
+EASYNEWS_PASSWORD=default_pass
+
+# Base URL used in generated NZB links (must be accessible by Aars, Prowlarr, etc.)
+FAKEARR_BASE_URL=http://debridav:5001
+
+# ===================================================
+# EasyNews+ (Sleeyax) parameters
+# Used only when EASYNEWS_VERSION=plus
+# ===================================================
+
+# Primary sort field
+EASYNEWS_SORT1=Size
+# Available: Size, Relevance, Extension, Expire, Date & Time, Filename, Subject, From, Group, Header, TPN, Set, Video Codec, Audio Codec, Image Size, A/V Length, Bitrate, Sample Rate, Frames Per Sec, Day
+
+# Primary sort direction
+EASYNEWS_SORT1_DIR=Descending
+# Available: Ascending, Descending
+
+# Secondary sort field
+EASYNEWS_SORT2=Relevance
+
+# Secondary sort direction
+EASYNEWS_SORT2_DIR=Descending
+
+# Tertiary sort field
+EASYNEWS_SORT3=Date & Time
+
+# Tertiary sort direction
+EASYNEWS_SORT3_DIR=Descending
+
+# ===================================================
+# EasyNews++ (panteLx) parameters
+# Used only when EASYNEWS_VERSION=plusplus
+# ===================================================
+
+# UI display language
+EASYNEWS_UI_LANGUAGE=eng
+# Available: eng, ger, spa, fre, ita, jpn, por, rus, kor, chi, dut, rum, bul
+
+# Enable strict title matching
+EASYNEWS_STRICT_TITLE_MATCHING=on
+# Available: on, off
+
+# Preferred audio language(s), comma-separated (e.g. eng,ger,spa)
+# Leave blank to include all languages
+EASYNEWS_PREFERRED_LANGUAGE=
+# Available: eng, ger, spa, fre, ita, jpn, por, rus, kor, chi, dut, rum, bul, ara, cze, dan, fin, gre, heb, hin, hun, ice, ind, may, nor, per, pol, swe, tha, tur, ukr, vie
+
+# Sorting preference for results
+# Leave blank to use addon default (quality_first)
+EASYNEWS_SORTING_PREFERENCE=quality_first
+# Available: quality_first, language_first, size_first, date_first
+
+# Which video qualities to include in results
+# Must match one of the predefined combinations from the addon
+# Leave blank to use addon default (4k,1080p,720p,480p)
+EASYNEWS_SHOW_QUALITIES=4k,1080p,720p
+# Available: 4k or 4k,1080p or 4k,1080p,720p or 4k,1080p,720p,480p or 1080p or 1080p,720p or 1080p,720p,480p or 720p or 720p,480p or 480p
+
+# Limit number of results per quality (0 = unlimited)
+# Leave blank to use addon default (unlimited)
+EASYNEWS_MAX_RESULTS_PER_QUALITY=0
+
+# Maximum file size in GB (0 = unlimited)
+# Leave blank to use addon default (unlimited)
+EASYNEWS_MAX_FILE_SIZE=0


### PR DESCRIPTION
This update adds support for EasyNews++ alongside the existing EasyNews+ integration. It standardizes metadata extraction, unifies attribute handling, and ensures correct formatting for fields like title, size, and usenet date.

**BREAKING CHANGE:**
The environment variable `EASYNEWSPLUS_URL` has been renamed to `EASYNEWS_ADDON_URL`. Additionally, several new environment variables have been introduced for both required and optional configuration. This means the new version is **not backward compatible** with earlier setups without updating the environment variables.